### PR TITLE
add EVENT_PVP_SLAY event

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1727,6 +1727,17 @@ bool Client::Death(Mob* killerMob, int32 damage, uint16 spell, EQ::skills::Skill
 				}
 			}
 		}
+
+		// check for a pvp kill
+		if (killerMob->IsClient()) {
+			Client* victim = this;
+			std::vector<EQ::Any> args;
+			args.push_back(victim);
+
+			parse->EventPlayer(EVENT_PVP_SLAY, killerMob->CastToClient(), victim->GetName(), victim->CharacterID(), &args);
+
+			mod_client_death_pvp(killerMob);
+		}
 	}
 
 	entity_list.RemoveFromTargets(this, true);

--- a/zone/client.h
+++ b/zone/client.h
@@ -1330,6 +1330,7 @@ public:
 	int32 mod_tribute_item_value(int32 pts, const EQ::ItemInstance* item);
 	void mod_client_death_npc(Mob* killerMob);
 	void mod_client_death_duel(Mob* killerMob);
+	void mod_client_death_pvp(Mob* killerMob);
 	void mod_client_death_env();
 	int32 mod_client_xp(int32 in_exp, NPC *npc);
 	uint32 mod_client_xp_for_level(uint32 xp, uint16 check_level);

--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -42,6 +42,7 @@ const char *QuestEventSubroutines[_LargestEventID] = {
 	"EVENT_COMBAT",
 	"EVENT_AGGRO",
 	"EVENT_SLAY",
+	"EVENT_PVP_SLAY",
 	"EVENT_NPC_SLAY",
 	"EVENT_WAYPOINT_ARRIVE",
 	"EVENT_WAYPOINT_DEPART",

--- a/zone/event_codes.h
+++ b/zone/event_codes.h
@@ -10,6 +10,7 @@ typedef enum {
 	EVENT_COMBAT,		//being attacked or attacking (resets after an interval of not being attacked)
 	EVENT_AGGRO,		//entering combat mode due to a PC attack
 	EVENT_SLAY,			//killing a PC
+	EVENT_PVP_SLAY,     // PC killing a PC
 	EVENT_NPC_SLAY,		//killing an NPC
 	EVENT_WAYPOINT_ARRIVE,	// reaching a waypoint on a grid
 	EVENT_WAYPOINT_DEPART,	// departing a waypoint on a grid

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -2930,6 +2930,7 @@ luabind::scope lua_register_events() {
 			luabind::value("spawn", static_cast<int>(EVENT_SPAWN)),
 			luabind::value("combat", static_cast<int>(EVENT_COMBAT)),
 			luabind::value("slay", static_cast<int>(EVENT_SLAY)),
+			luabind::value("pvp_slay", static_cast<int>(EVENT_PVP_SLAY)),
 			luabind::value("waypoint_arrive", static_cast<int>(EVENT_WAYPOINT_ARRIVE)),
 			luabind::value("waypoint_depart", static_cast<int>(EVENT_WAYPOINT_DEPART)),
 			luabind::value("timer", static_cast<int>(EVENT_TIMER)),

--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -49,6 +49,7 @@ const char *LuaEvents[_LargestEventID] = {
 	"event_combat",
 	"event_aggro",
 	"event_slay",
+	"event_pvp_slay",
 	"event_npc_slay",
 	"event_waypoint_arrive",
 	"event_waypoint_depart",
@@ -179,6 +180,7 @@ LuaParser::LuaParser() {
 
 	PlayerArgumentDispatch[EVENT_SAY] = handle_player_say;
 	PlayerArgumentDispatch[EVENT_ENVIRONMENTAL_DAMAGE] = handle_player_environmental_damage;
+	PlayerArgumentDispatch[EVENT_PVP_SLAY] = handle_pvp_slay;
 	PlayerArgumentDispatch[EVENT_DEATH] = handle_player_death;
 	PlayerArgumentDispatch[EVENT_DEATH_COMPLETE] = handle_player_death;
 	PlayerArgumentDispatch[EVENT_TIMER] = handle_player_timer;

--- a/zone/lua_parser_events.cpp
+++ b/zone/lua_parser_events.cpp
@@ -260,6 +260,14 @@ void handle_player_environmental_damage(QuestInterface *parse, lua_State* L, Cli
 	lua_setfield(L, -2, "env_final_damage");
 }
 
+void handle_pvp_slay(QuestInterface* parse, lua_State* L, Client* client, std::string data, uint32 extra_data,
+				     std::vector<EQ::Any>* extra_pointers) {
+	Lua_Client l_client(EQ::any_cast<Client*>(extra_pointers->at(0)));
+	luabind::adl::object l_client_o = luabind::adl::object(L, l_client);
+	l_client_o.push(L);
+	lua_setfield(L, -2, "other");
+}
+
 void handle_player_death(QuestInterface *parse, lua_State* L, Client* client, std::string data, uint32 extra_data,
 						 std::vector<EQ::Any> *extra_pointers) {
 	Seperator sep(data.c_str());

--- a/zone/lua_parser_events.h
+++ b/zone/lua_parser_events.h
@@ -47,6 +47,8 @@ void handle_player_say(QuestInterface *parse, lua_State* L, Client* client, std:
 		std::vector<EQ::Any> *extra_pointers);
 void handle_player_environmental_damage(QuestInterface *parse, lua_State* L, Client* client, std::string data, uint32 extra_data,
 	std::vector<EQ::Any> *extra_pointers);
+void handle_pvp_slay(QuestInterface* parse, lua_State* L, Client* npc, std::string data, uint32 extra_data,
+		std::vector<EQ::Any> *extra_pointers);
 void handle_player_death(QuestInterface *parse, lua_State* L, Client* client, std::string data, uint32 extra_data,
 		std::vector<EQ::Any> *extra_pointers);
 void handle_player_timer(QuestInterface *parse, lua_State* L, Client* client, std::string data, uint32 extra_data,

--- a/zone/mod_functions.cpp
+++ b/zone/mod_functions.cpp
@@ -96,6 +96,7 @@ int32 Client::mod_tribute_item_value(int32 pts, const EQ::ItemInstance* item) { 
 //Death reporting
 void Client::mod_client_death_npc(Mob* killerMob) { return; }
 void Client::mod_client_death_duel(Mob* killerMob) { return; }
+void Client::mod_client_death_pvp(Mob* killerMob) { return; }
 void Client::mod_client_death_env() { return; }
 
 //Calculated xp before consider modifier, called whenever a client gets XP for killing a mob.


### PR DESCRIPTION
hey guys, I added all of the lua events, bindings, and handler functions for a pvp slay event, as well as the logic in Client::Death() for firing the event in pvp. and tested it with the following lua script:
```lua
function event_pvp_slay(e)
    eq.zone_emote(0, e.other:GetName() .. " was killed by " .. e.self:GetName())
end
```
I only added lua bindings currently, let me know if you want perl bindings as well and I'd be happy to add them.
Should also be pretty easy to add a pvp death event as well, if you want that. btw I'm not 100% sure what the Death reporting stuff in `client.h` and `mod_functions.cpp` is used for, but I saw they send that packet on duel/npc/environmental deaths as well so I added it. let me know if you want it removed or any other fixes/changes and I'll work on it.