### PR TITLE
Mobs no longer drop loot or give exp when NPCs assist the player in killing

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2299,8 +2299,10 @@ bool NPC::Death(Mob* killer_mob, int32 damage, uint16 spell, EQ::skills::SkillTy
 		hate_list.AddEntToHateList(killer_mob, damage);
 
 	Mob* give_exp = nullptr;
+	bool npc_assisted = hate_list.IsNPCOnHateList();
 
-	if (!hate_list.IsNPCOnHateList()) {
+	// only give xp if an npc did not assist this kill
+	if (!npc_assisted) {
 		give_exp = hate_list.GetDamageTopOnHateList(this);
 
 		if (give_exp == nullptr)
@@ -2497,7 +2499,7 @@ bool NPC::Death(Mob* killer_mob, int32 damage, uint16 spell, EQ::skills::SkillTy
 	if (!HasOwner() && !IsMerc() && !GetSwarmInfo() && (!is_merchant || allow_merchant_corpse) &&
 		((killer && (killer->IsClient() || (killer->HasOwner() && killer->GetUltimateOwner()->IsClient()) ||
 		(killer->IsNPC() && killer->CastToNPC()->GetSwarmInfo() && killer->CastToNPC()->GetSwarmInfo()->GetOwner() && killer->CastToNPC()->GetSwarmInfo()->GetOwner()->IsClient())))
-		|| (killer_mob && IsLdonTreasure)))
+		|| (killer_mob && IsLdonTreasure)) && !npc_assisted)
 	{
 		if (killer != 0) {
 			if (killer->GetOwner() != 0 && killer->GetOwner()->IsClient())

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2298,10 +2298,14 @@ bool NPC::Death(Mob* killer_mob, int32 damage, uint16 spell, EQ::skills::SkillTy
 	if (killer_mob && GetClass() != LDON_TREASURE)
 		hate_list.AddEntToHateList(killer_mob, damage);
 
-	Mob *give_exp = hate_list.GetDamageTopOnHateList(this);
+	Mob* give_exp = nullptr;
 
-	if (give_exp == nullptr)
-		give_exp = killer;
+	if (!hate_list.IsNPCOnHateList()) {
+		give_exp = hate_list.GetDamageTopOnHateList(this);
+
+		if (give_exp == nullptr)
+			give_exp = killer;
+	}
 
 	if (give_exp && give_exp->HasOwner()) {
 

--- a/zone/hate_list.cpp
+++ b/zone/hate_list.cpp
@@ -86,6 +86,20 @@ bool HateList::IsEntOnHateList(Mob *mob)
 	return false;
 }
 
+bool HateList::IsNPCOnHateList()
+{
+	auto iterator = list.begin();
+	while (iterator != list.end())
+	{
+		if ((*iterator)->entity_on_hatelist->IsNPC() && !(*iterator)->entity_on_hatelist->IsPet()) {
+			return true;
+		}
+		++iterator;
+	}
+
+	return false;
+}
+
 struct_HateList *HateList::Find(Mob *in_entity)
 {
 	auto iterator = list.begin();

--- a/zone/hate_list.h
+++ b/zone/hate_list.h
@@ -50,6 +50,7 @@ public:
 	Mob *GetEscapingEntOnHateList(Mob *center, float range = 0.0f, bool first = false);
 
 	bool IsEntOnHateList(Mob *mob);
+	bool HateList::IsNPCOnHateList();
 	bool IsHateListEmpty();
 	bool RemoveEntFromHateList(Mob *ent);
 


### PR DESCRIPTION
Added a function to `HateList` to determine if an NPC is on the list via iterator and `IsNPC()` checks. Used logic in `NPC::Death()` to prevent players from getting XP, faction, or loot when an NPC interferes in their fight.

Tested this with pets, pets + guard, normal solo kills. Used enchanter with charmed pet, dropped pet after it dealt damage, and killed mob to confirm enchanter still got xp in that scenario.. all testing checked out.