### PR TITLE
fixed bards being able to equip instrument+weapon

### DIFF
--- a/common/inventory_profile.cpp
+++ b/common/inventory_profile.cpp
@@ -338,6 +338,9 @@ bool EQ::InventoryProfile::SwapItem(
 	ItemInstance *source_item_instance      = GetItem(source_slot);
 	ItemInstance *destination_item_instance = GetItem(destination_slot);
 
+	ItemInstance* primary_weapon		    = GetItem(EQ::invslot::slotPrimary);
+	ItemInstance* secondary_weapon			= GetItem(EQ::invslot::slotSecondary);
+
 	if (source_item_instance) {
 		if (!source_item_instance->IsSlotAllowed(destination_slot)) {
 			fail_state = swapNotAllowed;
@@ -360,6 +363,35 @@ bool EQ::InventoryProfile::SwapItem(
 			if (level && source_item->ReqLevel && level < source_item->ReqLevel) {
 				fail_state = swapLevel;
 				return false;
+			}
+			if (destination_slot == EQ::invslot::slotPrimary && secondary_weapon) {
+				uint8 instrument = secondary_weapon->GetItem()->ItemType;
+				if (
+					instrument == EQ::item::ItemTypeWindInstrument ||
+					instrument == EQ::item::ItemTypeStringedInstrument ||
+					instrument == EQ::item::ItemTypeBrassInstrument ||
+					instrument == EQ::item::ItemTypePercussionInstrument
+					) {
+					LogInventory("Cannot equip a primary item with [{}] already in the secondary.", secondary_weapon->GetItem()->Name);
+					fail_state = swapPrimaryInstrument;
+					return false;
+				}
+			}
+
+			if (destination_slot == EQ::invslot::slotSecondary && primary_weapon) {
+				if (source_item_instance) {
+					uint8 instrument = source_item_instance->GetItem()->ItemType;
+					if (
+						instrument == EQ::item::ItemTypeWindInstrument ||
+						instrument == EQ::item::ItemTypeStringedInstrument ||
+						instrument == EQ::item::ItemTypeBrassInstrument ||
+						instrument == EQ::item::ItemTypePercussionInstrument
+						) {
+						LogInventory("Cannot equip an instrument with [{}] already in the primary.", primary_weapon->GetItem()->Name);
+						fail_state = swapInstrument;
+						return false;
+					}
+				}
 			}
 		}
 	}

--- a/common/inventory_profile.h
+++ b/common/inventory_profile.h
@@ -128,7 +128,7 @@ namespace EQ
 		ItemInstance* GetCursorItem();
 
 		// Swap items in inventory
-		enum SwapItemFailState : int8 { swapInvalid = -1, swapPass = 0, swapNotAllowed, swapNullData, swapRaceClass, swapDeity, swapLevel };
+		enum SwapItemFailState : int8 { swapInvalid = -1, swapPass = 0, swapNotAllowed, swapNullData, swapRaceClass, swapDeity, swapLevel, swapPrimaryInstrument, swapInstrument };
 		bool SwapItem(int16 source_slot, int16 destination_slot, SwapItemFailState& fail_state, uint16 race_id = 0, uint8 class_id = 0, uint16 deity_id = 0, uint8 level = 0);
 
 		// Remove item from inventory

--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -1960,6 +1960,10 @@ bool Client::SwapItem(MoveItem_Struct* move_in) {
 				fail_message = "Your class, deity and/or race may not equip that item.";
 			else if (fail_state == EQ::InventoryProfile::swapLevel)
 				fail_message = "You are not sufficient level to use this item.";
+			else if (fail_state == EQ::InventoryProfile::swapPrimaryInstrument)
+				fail_message = "Cannot equip a primary weapon with instrument in secondary.";
+			else if (fail_state == EQ::InventoryProfile::swapInstrument)
+				fail_message = "Cannot equip an instrument with weapon in primary.";
 
 			if (fail_message)
 				Message(Chat::Red, "%s", fail_message);


### PR DESCRIPTION
need to deal with inventory desync; the same one that happens on rof2 when a level-restricted item is equipped on a character that is too low level to use it