### PR TITLE
fix pvp resist function

### DIFF
--- a/zone/lua_mod.cpp
+++ b/zone/lua_mod.cpp
@@ -692,7 +692,9 @@ void LuaMod::ClientDamage(Client *self, Mob *other, int32 &in_damage, uint16 &sp
 }
 
 void LuaMod::PVPResistSpell(Client* self, uint8 &resist_type, uint16 &spell_id, Client* caster, bool &use_resist_override, int &resist_override, bool &CharismaCheck,
-							bool &CharmTick, bool &IsRoot, int &level_override, float &out_index, bool &ignoreDefault) {
+							bool &CharmTick, bool &IsRoot, int &level_override, float &returnValue, bool &ignoreDefault) {
+	float retval = 0;
+	int start = lua_gettop(L);
 	try {
 		if (!m_has_pvp_resist_spell) {
 			return;
@@ -733,14 +735,19 @@ void LuaMod::PVPResistSpell(Client* self, uint8 &resist_type, uint16 &spell_id, 
 
 			auto returnValueObj = ret["ReturnValue"];
 			if (luabind::type(returnValueObj) == LUA_TNUMBER) {
-				// out_index is the effectiveness index of the spell, see Mob::ResistSpell
-				out_index = luabind::object_cast<int32>(returnValueObj);
+				returnValue = luabind::object_cast<float>(returnValueObj);
 			}
 		}
 
 	}
 	catch (std::exception & ex) {
 		parser_->AddError(ex.what());
+	}
+
+	int end = lua_gettop(L);
+	int n = end - start;
+	if (n > 0) {
+		lua_pop(L, n);
 	}
 }
 

--- a/zone/lua_mod.h
+++ b/zone/lua_mod.h
@@ -27,7 +27,7 @@ public:
 	void GetEXPForLevel(Client *self, uint16 level, uint32 &returnValue, bool &ignoreDefault);
 	void GetExperienceForKill(Client *self, Mob *against, uint32 &returnValue, bool &ignoreDefault);
 	void ClientDamage(Client *self, Mob *other, int32 &in_damage, uint16 &spell_id,  int &attack_skill, bool &avoidable, int8 &buffslot, bool &iBuffTic, int &special, int32 &out_damage, bool &ignoreDefault);
-	void PVPResistSpell(Client *self, uint8 &resist_type, uint16 &spell_id, Client *caster, bool &use_resist_override, int &resist_override, bool &CharismaCheck, bool &CharmTick, bool &IsRoot, int &level_override, float &out_index, bool &ignoreDefault);
+	void PVPResistSpell(Client *self, uint8 &resist_type, uint16 &spell_id, Client *caster, bool &use_resist_override, int &resist_override, bool &CharismaCheck, bool &CharmTick, bool &IsRoot, int &level_override, float &returnValue, bool &ignoreDefault);
 private:
 	LuaParser *parser_;
 	lua_State *L;

--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -1389,10 +1389,10 @@ void LuaParser::ClientDamage(Client *self, Mob *other, int32 &in_damage, uint16 
 	}
 }
 
-float LuaParser::PVPResistSpell(Client* self, uint8 &resist_type, uint16 &spell_id, Client* caster, bool &use_resist_override, int &resist_override, bool &CharismaCheck, bool &CharmTick, bool &IsRoot, int &level_override, float &out_index, bool &ignoreDefault) {
+float LuaParser::PVPResistSpell(Client* self, uint8 &resist_type, uint16 &spell_id, Client* caster, bool &use_resist_override, int &resist_override, bool &CharismaCheck, bool &CharmTick, bool &IsRoot, int &level_override, bool &ignoreDefault) {
 	float retval = 0;
 	for (auto &mod : mods_) {
-		mod.PVPResistSpell(self, resist_type, spell_id, caster, use_resist_override, resist_override, CharismaCheck, CharmTick, IsRoot, level_override, out_index, ignoreDefault);
+		mod.PVPResistSpell(self, resist_type, spell_id, caster, use_resist_override, resist_override, CharismaCheck, CharmTick, IsRoot, level_override, retval, ignoreDefault);
 	}
 	return retval;
 }

--- a/zone/lua_parser.h
+++ b/zone/lua_parser.h
@@ -100,7 +100,7 @@ public:
 	uint32 GetEXPForLevel(Client *self, uint16 level, bool &ignoreDefault);
 	uint32 GetExperienceForKill(Client *self, Mob *against, bool &ignoreDefault);
 	void ClientDamage(Client *self, Mob *other, int32 &in_damage, uint16 &spell_id,  int &attack_skill, bool &avoidable, int8 &buffslot, bool &iBuffTic, int &special, int32 &out_damage, bool &ignoreDefault);
-	float LuaParser::PVPResistSpell(Client* self, uint8 &resist_type, uint16 &spell_id, Client* caster, bool &use_resist_override, int &resist_override, bool &CharismaCheck, bool &CharmTick, bool &IsRoot, int &level_override, float &out_index, bool &ignoreDefault);
+	float PVPResistSpell(Client* self, uint8 &resist_type, uint16 &spell_id, Client* caster, bool &use_resist_override, int &resist_override, bool &CharismaCheck, bool &CharmTick, bool &IsRoot, int &level_override, bool &ignoreDefault);
 
 private:
 	LuaParser();

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4480,12 +4480,12 @@ float Mob::ResistSpell(uint8 resist_type, uint16 spell_id, Mob *caster, bool use
 #ifdef LUA_EQEMU
 	// for pvp override, caster and resistor must both be clients
 	if (this->IsClient() && caster->IsClient()) {
-		float out_index;
-		float lua_ret;
+		float returnValue;
 		bool ignoreDefault = false;
-		lua_ret = LuaParser::Instance()->PVPResistSpell(this->CastToClient(), resist_type, spell_id, caster->CastToClient(), use_resist_override, resist_override, CharismaCheck, CharmTick, IsRoot, level_override, out_index, ignoreDefault);
+		float lua_ret = LuaParser::Instance()->PVPResistSpell(this->CastToClient(), resist_type, spell_id, caster->CastToClient(), use_resist_override, resist_override, CharismaCheck, CharmTick, IsRoot, level_override, ignoreDefault);
 
-		if (ignoreDefault && lua_ret) {
+		if (ignoreDefault) {
+			LogDebug("Default ignored, lua return value is: [{}]", lua_ret);
 			return lua_ret;
 		}
 	}


### PR DESCRIPTION
removed return value from the parser, it should only be in the module. also fixed cast from int32 to float, and made sure to pop the lua states at the end of our call to the lua module.

also removed check for lua_ret as its unnecessary, lua programmer needs to ensure e.IgnoreDefault = true if they want to use the pvp spell resists.