### PR TITLE
Improve taunt reliability at max skill

### DIFF
--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -1993,9 +1993,9 @@ void Mob::Taunt(NPC *who, bool always_succeed, int chance_bonus, bool FromSpell,
 			else {
 
 				if (level_difference < 0) {
-					tauntchance += static_cast<float>(level_difference) * 4.0f;
-					if (tauntchance < 15)
-						tauntchance = 15.0f;
+					tauntchance += static_cast<float>(level_difference) * 2.0f;
+					if (tauntchance < 20)
+						tauntchance = 20.0f;
 				}
 
 				else {
@@ -2029,7 +2029,7 @@ void Mob::Taunt(NPC *who, bool always_succeed, int chance_bonus, bool FromSpell,
 				who->CastToNPC()->AddToHateList(this, newhate);
 				Success = true;
 			} else {
-				who->CastToNPC()->AddToHateList(this, GetSkill(EQ::skills::SkillTaunt));
+				who->CastToNPC()->AddToHateList(this, (GetSkill(EQ::skills::SkillTaunt) / 10));
 			}
 
 			if (who->CanTalk())

--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -1976,12 +1976,16 @@ void Mob::Taunt(NPC *who, bool always_succeed, int chance_bonus, bool FromSpell,
 	}
 
 	// All values used based on live parses after taunt was updated in 2006.
+    // Update to make taunt slightly more reliable at max skill (fitz, Sept 2021)
 	if ((hate_top && hate_top->GetHPRatio() >= 20) || hate_top == nullptr || chance_bonus) {
 		// SE_Taunt this is flat chance
 		if (chance_bonus) {
 			Success = zone->random.Roll(chance_bonus);
 		} else {
 			float tauntchance = 50.0f;
+			
+			if (GetSkill(EQ::skills::SkillTaunt) >= 200)
+				tauntchance = 65.0f;
 
 			if (always_succeed)
 				tauntchance = 101.0f;
@@ -1989,15 +1993,18 @@ void Mob::Taunt(NPC *who, bool always_succeed, int chance_bonus, bool FromSpell,
 			else {
 
 				if (level_difference < 0) {
-					tauntchance += static_cast<float>(level_difference) * 3.0f;
-					if (tauntchance < 20)
-						tauntchance = 20.0f;
+					tauntchance += static_cast<float>(level_difference) * 4.0f;
+					if (tauntchance < 15)
+						tauntchance = 15.0f;
 				}
 
 				else {
 					tauntchance += static_cast<float>(level_difference) * 5.0f;
-					if (tauntchance > 65)
-						tauntchance = 65.0f;
+					if (tauntchance > 85)
+						tauntchance = 85.0f;
+					
+				if ((tauntchance > 95) && (GetSkill(EQ::skills::SkillTaunt) >= 200))
+						tauntchance = 95.0f;
 				}
 			}
 
@@ -2022,7 +2029,7 @@ void Mob::Taunt(NPC *who, bool always_succeed, int chance_bonus, bool FromSpell,
 				who->CastToNPC()->AddToHateList(this, newhate);
 				Success = true;
 			} else {
-				who->CastToNPC()->AddToHateList(this, 12);
+				who->CastToNPC()->AddToHateList(this, GetSkill(EQ::skills::SkillTaunt));
 			}
 
 			if (who->CanTalk())


### PR DESCRIPTION
* Change starting chance from 50% to 65% at once at max skill
* Change success minimum (floor) on yellow or higher mobs from 20% to 15%, increase multiplier to compensate.
* Change success cap (ceiling) on white or lower mobs from 65% -> 85% (never less than a 15% chance of failure.)
* Change success cap (ceiling) on white or lower mobs at max skill to 95% (never less than a 5% chance of failure.)
* Add taunt skill's worth of hate to mob if already attacking you instead of a flat value, to help tanks scale with level.